### PR TITLE
Update Data360 Open_API.json

### DIFF
--- a/Data360 Open_API.json
+++ b/Data360 Open_API.json
@@ -176,7 +176,7 @@
           "Data"
         ],
         "parameters": [
-          { "$ref": "#/components/parameters/databaseIdQueryInd" }
+          { "$ref": "#/components/parameters/datasetIdQuery" }
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
Change parameter of /data360/indicators from databaseIdQueryInd to datasetIdQuery. To respond to user reports that databaseId as parameter returns 400.